### PR TITLE
Scrolling mechanism

### DIFF
--- a/src/Panel/Update.elm
+++ b/src/Panel/Update.elm
@@ -148,6 +148,28 @@ update message model =
                           }
                         , Cmd.none
                         )
+
+                -- explicit define space so it will not scroll page to bottom
+                32 ->
+                    let
+                        char = " "
+                        x = fst model.cursor
+                        y = snd model.cursor
+                        front = List.take x model.lines
+                        back = List.drop (x + 1) model.lines
+                        middle =
+                            case nth x model.lines of
+                                Nothing -> [char]
+                                Just line -> [addToString line y char]
+                        lines = front ++ middle ++ back
+                    in
+                        ( { model |
+                                lines = lines,
+                                cursor = (x,y + 1)
+                          }
+                        ,Cmd.none
+                        )
+
                 -- left/right
                 37 ->
                     ( { model | cursor = left model }, Cmd.none)

--- a/src/Panel/Update.elm
+++ b/src/Panel/Update.elm
@@ -177,9 +177,9 @@ update message model =
                     ( { model | cursor = right model }, Cmd.none)
                 -- up/down
                 38 ->
-                    ( { model | cursor = up model }, Cmd.none)
+                    ( { model | cursor = up model }, command "core:line-up" )
                 40 ->
-                    ( { model | cursor = down model }, Cmd.none)
+                    ( { model | cursor = down model }, command "core:line-down" )
                 _ ->
                     ( model, Cmd.none )
 
@@ -340,3 +340,4 @@ down model =
 
 
 port command : String -> Cmd msg
+--port scroll : Int -> Cmd msg

--- a/src/Panel/View.elm
+++ b/src/Panel/View.elm
@@ -41,12 +41,13 @@ cursorLeft y =
 
 view : Model -> Html Msg
 view model =
-    pre [ class "pan" ]
+    pre [ id "panel", class "pan" ]
         [ div [ class "layer code-layer" ] (List.map renderLine model.lines)
         , div
               [ class "layer cursor-layer"]
               [ div
                 [ class "cursor"
+                , id "cursor"
                 , style
                       [ ("top", cursorTop (fst model.cursor) )
                       , ("left", cursorLeft (snd model.cursor) )

--- a/web/ports.js
+++ b/web/ports.js
@@ -15,3 +15,10 @@ ipcRenderer.on("open-file", function(event, data) {
   app.ports.onCommand.send(data);
 });
 
+
+// remove arrow and space scroll
+window.addEventListener("keydown", function(e) {
+  if([32, 37, 38, 39, 40].indexOf(e.keyCode) > -1) {
+    e.preventDefault();
+  }
+}, false);

--- a/web/ports.js
+++ b/web/ports.js
@@ -5,10 +5,22 @@ const ipcRenderer = electron.ipcRenderer;
 
 // ports here
 app.ports.command.subscribe(function(command) {
-  ipcRenderer.send(command);
-  ipcRenderer.on(command, function(event, data) {
-    app.ports.onCommand.send(data);
-  });
+  if(command == "core:line-up") {
+    // this may not work on solwer machines
+    setTimeout(() => {
+      document.getElementById("cursor").scrollIntoViewIfNeeded(false);
+    }, 50);
+  } else if (command == "core:line-down") {
+    // this may not work on solwer machines
+    setTimeout(() => {
+      document.getElementById("cursor").scrollIntoViewIfNeeded(false);
+    }, 50);
+  } else {
+    ipcRenderer.send(command);
+    ipcRenderer.on(command, function(event, data) {
+      app.ports.onCommand.send(data);
+    });
+  }
 });
 
 ipcRenderer.on("open-file", function(event, data) {


### PR DESCRIPTION
Default panel (buffer) has `x` and `y` overflow. This PR prevents scrolling by arrow keys and space bar. It also adds scrolling to cursor it he reaches top or bottom of panel.

It's made using command port to JavaScript which uses `element.scrollIntoViewIfNeeded(false)` after 50ms timeout which gives Elm time to re-render cursor. This solution may not be very elegant but it works which is crucial for now. At some point we will have to go back and create proper implementation but I'm not sure how it will work right now.
